### PR TITLE
Re-apply original copyright years

### DIFF
--- a/tests/locks_test/src/helper.c
+++ b/tests/locks_test/src/helper.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2014-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #if USE_HW_LOCK
 #else

--- a/tests/locks_test/src/main.xc
+++ b/tests/locks_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2014-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <platform.h>


### PR DESCRIPTION
The fixed infr_apps source checker can handle copyright dates that predate the git history, so re-apply the original copyright years.